### PR TITLE
callable: fix issue with entire NO_COVERAGE block

### DIFF
--- a/depth/depth.go
+++ b/depth/depth.go
@@ -313,12 +313,18 @@ func run(args dargs) {
 			}
 			line, err = rdr.ReadString('\n')
 		}
-		if len(cache) > 1 {
+		if len(cache) > 1 && lastChrom != "" && cache[0].pos != 0 {
 			fhCA.WriteString(fmt.Sprintf("%s\t%d\t%d\t%s\n", lastChrom, cache[0].pos-1, cache[1].pos, lastCovClass))
 		}
 		// we didn't get data for the full region, so it must end in no-coverage.
 		if cache[1].pos < regionEnd {
-			fhCA.WriteString(fmt.Sprintf("%s\t%d\t%d\tNO_COVERAGE\n", lastChrom, cache[1].pos, regionEnd))
+			// If we had regions within section
+			if cache[1].pos != 0 {
+				fhCA.WriteString(fmt.Sprintf("%s\t%d\t%d\tNO_COVERAGE\n", lastChrom, cache[1].pos, regionEnd))
+				// otherwise the whole region is NO_COVERAGE
+			} else {
+				fhCA.WriteString(fmt.Sprintf("%s\t%d\t%d\tNO_COVERAGE\n", chrom, start, regionEnd))
+			}
 			for ds := cache[1].pos / args.WindowSize * args.WindowSize; ds < regionEnd; ds += args.WindowSize {
 				thisWindow := ds / args.WindowSize
 				stats := getStats(fa, chrom, thisWindow, thisWindow+args.WindowSize)

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/brentp/goleft/depth"
 )
 
-const Version = "0.1.1"
+const Version = "0.1.2"
 
 type progPair struct {
 	help string


### PR DESCRIPTION
Brent;
Spotted this issue during testing with the new coverage implementation in bcbio. You can replicate with the previous test case:
```
wget https://s3.amazonaws.com/chapmanb/testcases/goleft_callable.tar.gz
```
If you edit `Test1-coverage.depth-tocalculate-windows.bed` to include:
```
chr22	15750	15800
```
Feel free to suck that test case up into goleft if it help, sorry meant to say that's totally fine earlier. If we can push a new version with this fix I'll update the conda packages to unbreak current bcbio development.

If a BED region input has NO_COVERAGE over the full block, the final
condition results in incorrect output. For a pretend region on
chr1:1000-1250, this looked like:
```
   -1   0
   0    1250   NO_COVERAGE
```
This catches this condition and correctly writes out the final block
as NO_COVERAGE over the full region.