### PR TITLE
v1.0.6 bump: Fix help request escaping

### DIFF
--- a/depth/depth.go
+++ b/depth/depth.go
@@ -35,7 +35,7 @@ type dargs struct {
 	Reference    string `arg:"-r,required,help:path to reference fasta"`
 	Processes    int    `arg:"-p,help:number of processors to parallelize."`
 	Bed          string `arg:"-b,help:optional file of positions or regions to restrict depth calculations."`
-	Prefix       string `arg:"positional,required,help:prefix for output files -depth.bed, -callable.bed"`
+	Prefix       string `arg:"positional,required,help:prefix for output files \-depth.bed, \-callable.bed"`
 	Bam          string `arg:"positional,required,help:bam for which to calculate depth"`
 }
 

--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/brentp/goleft/depth"
 )
 
-const Version = "0.1.5"
+const Version = "0.1.6"
 
 type progPair struct {
 	help string


### PR DESCRIPTION
1.0.5 had issues with escaping some of the help commands causing Travis
CI builds for bioconda to fail:
```
./goleft depth -h
unrecognized tag ' -callable.bed' on field positional,required,help:prefix for output files -depth.bed, -callable.bed
```
This fixes the escaping so we can hopefully update the PR and get the
conda packages pushed.